### PR TITLE
Potential fix for code scanning alert no. 7: Use of externally-controlled format string

### DIFF
--- a/src/tools/echo-ping/src/server.ts
+++ b/src/tools/echo-ping/src/server.ts
@@ -35,7 +35,7 @@ export class EchoMCPServer {
   }
 
   async handlePostRequest(req: Request, res: Response) {
-    console.log(`POST ${req.originalUrl} (${req.ip}) - payload:`, req.body);
+    console.log('POST %s (%s) - payload:', req.originalUrl, req.ip, req.body);
     try {
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,


### PR DESCRIPTION
Potential fix for [https://github.com/elbruno/contoso-travel-agents/security/code-scanning/7](https://github.com/elbruno/contoso-travel-agents/security/code-scanning/7)

To fix the issue, we will sanitize the untrusted input (`req.originalUrl` and `req.ip`) before including it in the log message. Specifically, we will ensure that these values are treated as plain strings by using the `%s` format specifier in `console.log` and passing the untrusted data as separate arguments. This approach prevents any unintended interpretation of the input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
